### PR TITLE
Don't use the Hash constructor if there's only one field

### DIFF
--- a/lib/immutable_struct.rb
+++ b/lib/immutable_struct.rb
@@ -25,7 +25,7 @@ private
       alias_method :struct_initialize, :initialize
 
       def initialize(*attrs)
-        if attrs && attrs.size == 1 && attrs.first.is_a?(Hash)
+        if members.size > 1 && attrs && attrs.size == 1 && attrs.first.instance_of?(Hash)
           struct_initialize(*members.map { |m| attrs.first[m.to_sym] })
         else
           struct_initialize(*attrs)

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -51,6 +51,11 @@ describe ImmutableStruct do
     obj.b.should == 2
   end
   
+  it 'does not create a hash constructor for single-field instances' do
+    obj = ImmutableStruct.new(:a).new(:some => :data)
+    obj.a.should == {:some => :data}
+  end
+  
   it 'adds #to_h that returns a hash representation of the object' do
     obj = ImmutableItem.new(:a => 1, :b => 2)
     obj.to_h.should have_key(:a)


### PR DESCRIPTION
This test case is probably why Struct does not define a constructor taking a Hash. The fix makes it OK in the most common case but is not 100% bulletproof.
