### PR TITLE
Raise exception on unknown keyword arguments

### DIFF
--- a/lib/immutable_struct.rb
+++ b/lib/immutable_struct.rb
@@ -26,7 +26,13 @@ private
 
       def initialize(*attrs)
         if members.size > 1 && attrs && attrs.size == 1 && attrs.first.instance_of?(Hash)
-          struct_initialize(*members.map { |m| attrs.first[m.to_sym] })
+          kws = attrs.first
+          extra = kws.keys - members
+          if extra.empty?
+            struct_initialize(*members.map { |m| kws[m] })
+          else
+            raise ArgumentError.new("unknown #{extra.size == 1 ? "keyword" : "keywords"}: #{extra.join(", ")}")
+          end
         else
           struct_initialize(*attrs)
         end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -50,7 +50,19 @@ describe ImmutableStruct do
     obj.a.should == nil
     obj.b.should == 2
   end
-  
+
+  it 'creates a constructor that throws an exception on unknown keyword argument' do
+    running {
+      ImmutableItem.new(:a => 1, :b => 2, :c => 3)
+    }.should raise_error(ArgumentError, "unknown keyword: c")
+  end
+
+  it 'creates a constructor that includes detailed error message on multiple unknown keyword arguments' do
+    running {
+      ImmutableItem.new(:a => 1, :b => 2, :foo => 3, :bar => 4, :baz => 5)
+    }.should raise_error(ArgumentError, "unknown keywords: foo, bar, baz")
+  end
+
   it 'does not create a hash constructor for single-field instances' do
     obj = ImmutableStruct.new(:a).new(:some => :data)
     obj.a.should == {:some => :data}


### PR DESCRIPTION
The error message is exactly the same as what we get with Ruby 2.0
keyword arguments.
