### PR TITLE
Added YAML deserialization

### DIFF
--- a/lib/immutable_struct.rb
+++ b/lib/immutable_struct.rb
@@ -16,11 +16,7 @@ private
   def self.make_immutable!(struct)
     struct.send(:undef_method, "[]=".to_sym)
     struct.members.each do |member|
-      original_setter = "#{member}=".to_sym
-      private_setter  = "_#{member}=".to_sym
-      struct.send(:alias_method, private_setter, original_setter)
-      struct.send(:private, private_setter)
-      struct.send(:undef_method, original_setter)
+      struct.send(:undef_method, "#{member}=".to_sym)
     end
   end
   
@@ -50,9 +46,7 @@ private
       end
 
       def init_with(coder)
-        coder.map.each do |k, v|
-          send("_#{k}=", v)
-        end
+        struct_initialize(*members.map { |m| coder.map[m.to_s] })
       end
 
     end

--- a/lib/immutable_struct.rb
+++ b/lib/immutable_struct.rb
@@ -2,7 +2,7 @@
 
 class ImmutableStruct
   VERSION = '1.1.1'
-
+  
   def self.new(*attrs, &block)
     struct = Struct.new(*attrs, &block)
     make_immutable!(struct)
@@ -10,7 +10,7 @@ class ImmutableStruct
     extend_dup!(struct)
     struct
   end
-
+  
 private
 
   def self.make_immutable!(struct)
@@ -23,7 +23,7 @@ private
       struct.send(:undef_method, original_setter)
     end
   end
-
+  
   def self.optionalize_constructor!(struct)
     struct.class_eval do
       alias_method :struct_initialize, :initialize
@@ -35,7 +35,7 @@ private
           struct_initialize(*attrs)
         end
       end
-
+      
       def to_h
         members.inject({}) do |h, m|
           h[m.to_sym] = self[m]
@@ -57,7 +57,7 @@ private
 
     end
   end
-
+  
   def self.extend_dup!(struct)
     struct.class_eval do
       def dup(overrides={})

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -4,7 +4,7 @@ require './spec/spec_helper'
 
 
 describe ImmutableStruct do
-  
+
   class ImmutableItem < ImmutableStruct.new(:a, :b); end
 
   ImmutableAdder = ImmutableStruct.new(:a, :b) do
@@ -12,7 +12,7 @@ describe ImmutableStruct do
       a + b
     end
   end
-  
+
   it 'can be used as a superclass just like Struct' do
     obj = ImmutableItem.new(1, 2)
     obj.a.should == 1
@@ -22,17 +22,17 @@ describe ImmutableStruct do
     obj = ImmutableAdder.new(1, 2)
     obj.sum.should == 3
   end
-  
+
   it 'creates no setters' do
     obj = ImmutableItem.new(1, 2)
     running { obj.a = 3 }.should raise_error
   end
-  
+
   it 'does not allow [] to be used to mutate the instance' do
     obj = ImmutableItem.new(1, 2)
     running { obj[:a] = 3 }.should raise_error
   end
-  
+
   it 'creates a constructor that works like the one Struct creates' do
     obj = ImmutableItem.new(1, 2)
     obj.a.should == 1
@@ -41,7 +41,7 @@ describe ImmutableStruct do
     obj.a.should == 1
     obj.b.should == nil
   end
-  
+
   it 'creates a constructor that takes a hash' do
     obj = ImmutableItem.new(:a => 1, :b => 2)
     obj.a.should == 1
@@ -50,22 +50,29 @@ describe ImmutableStruct do
     obj.a.should == nil
     obj.b.should == 2
   end
-  
+
   it 'does not create a hash constructor for single-field instances' do
     obj = ImmutableStruct.new(:a).new(:some => :data)
     obj.a.should == {:some => :data}
   end
-  
+
   it 'adds #to_h that returns a hash representation of the object' do
     obj = ImmutableItem.new(:a => 1, :b => 2)
     obj.to_h.should have_key(:a)
     obj.to_h.should have_key(:b)
   end
-  
+
   it 'extends #dup so that properties can be overridden' do
     obj1 = ImmutableItem.new(:a => 1, :b => 2)
     obj2 = obj1.dup(:b => 3)
     obj2.b.should == 3
   end
-  
+
+  it "can be deserialized from YAML" do
+    obj1 = ImmutableItem.new(:a => 1, :b => 2)
+    yaml = YAML.dump(obj1)
+    obj2 = YAML.load(yaml)
+    obj2.should == obj1
+  end
+
 end

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -4,7 +4,7 @@ require './spec/spec_helper'
 
 
 describe ImmutableStruct do
-
+  
   class ImmutableItem < ImmutableStruct.new(:a, :b); end
 
   ImmutableAdder = ImmutableStruct.new(:a, :b) do
@@ -12,7 +12,7 @@ describe ImmutableStruct do
       a + b
     end
   end
-
+  
   it 'can be used as a superclass just like Struct' do
     obj = ImmutableItem.new(1, 2)
     obj.a.should == 1
@@ -22,17 +22,17 @@ describe ImmutableStruct do
     obj = ImmutableAdder.new(1, 2)
     obj.sum.should == 3
   end
-
+  
   it 'creates no setters' do
     obj = ImmutableItem.new(1, 2)
     running { obj.a = 3 }.should raise_error
   end
-
+  
   it 'does not allow [] to be used to mutate the instance' do
     obj = ImmutableItem.new(1, 2)
     running { obj[:a] = 3 }.should raise_error
   end
-
+  
   it 'creates a constructor that works like the one Struct creates' do
     obj = ImmutableItem.new(1, 2)
     obj.a.should == 1
@@ -41,7 +41,7 @@ describe ImmutableStruct do
     obj.a.should == 1
     obj.b.should == nil
   end
-
+  
   it 'creates a constructor that takes a hash' do
     obj = ImmutableItem.new(:a => 1, :b => 2)
     obj.a.should == 1
@@ -50,29 +50,29 @@ describe ImmutableStruct do
     obj.a.should == nil
     obj.b.should == 2
   end
-
+  
   it 'does not create a hash constructor for single-field instances' do
     obj = ImmutableStruct.new(:a).new(:some => :data)
     obj.a.should == {:some => :data}
   end
-
+  
   it 'adds #to_h that returns a hash representation of the object' do
     obj = ImmutableItem.new(:a => 1, :b => 2)
     obj.to_h.should have_key(:a)
     obj.to_h.should have_key(:b)
   end
-
+  
   it 'extends #dup so that properties can be overridden' do
     obj1 = ImmutableItem.new(:a => 1, :b => 2)
     obj2 = obj1.dup(:b => 3)
     obj2.b.should == 3
   end
-
+  
   it "can be deserialized from YAML" do
     obj1 = ImmutableItem.new(:a => 1, :b => 2)
     yaml = YAML.dump(obj1)
     obj2 = YAML.load(yaml)
     obj2.should == obj1
   end
-
+  
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ require 'yaml'
 alias :running :lambda
 
 RSpec.configure do |config|
-
+  
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,11 @@
 $: << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'immutable_struct'
+require 'yaml'
 
 
 alias :running :lambda
 
 RSpec.configure do |config|
-  
+
 end


### PR DESCRIPTION
It was currently impossible to deserialize an `ImmutableStruct` serialized to YAML since the default behaviour relies on the availability of public setters. I've worked around the issue by make a private alias of the public setters before undefining them.

I'm very well conscious that this creates a potential backdoor for mutability but, at least in the case of the application I'm currently working on, it's a trade off worth considering. 
Perhaps that this feature can be made optional by the inclusion of a module?

Tested with 1.9.3 and 2.0.0.
