### PR TITLE
Add strict mode

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -16,5 +16,12 @@ In addition to the above, `ImmutableStruct` enhances the constructor to accept a
     ship = Spaceship.new(:max_speed => '∞', :name => 'The TARDIS')
     
     puts ship.max_speed # => ∞
+
+You can create a strict version of the struct, which will raise an error if you initialize it with a Hash that does not contain all the fields
+of the struct
+
+    StrictSpaceship = Spaceship.strict
+
+    strict_ship = StrictSpaceship.new(:name => 'Enterprise') # raises ArgumentError
     
 I'm surprised every time I look at the RDoc for `Struct` that it doesn't do this.

--- a/lib/immutable_struct.rb
+++ b/lib/immutable_struct.rb
@@ -10,13 +10,19 @@ class ImmutableStruct
     extend_dup!(struct)
     struct
   end
-  
+
 private
 
   def self.make_immutable!(struct)
     struct.send(:undef_method, "[]=".to_sym)
     struct.members.each do |member|
       struct.send(:undef_method, "#{member}=".to_sym)
+    end
+    struct.instance_variable_set('@strict_mode', false)
+    struct.define_singleton_method(:strict) do
+      cl = self.clone
+      cl.instance_variable_set('@strict_mode', true)
+      cl
     end
   end
   
@@ -26,6 +32,14 @@ private
 
       def initialize(*attrs)
         if members.size > 1 && attrs && attrs.size == 1 && attrs.first.instance_of?(Hash)
+          strict = self.class.instance_variable_get('@strict_mode')
+          if strict
+            attr_keys = attrs.first.keys.map(&:to_sym)
+            diff = members - attr_keys
+            unless diff.empty?
+              raise ArgumentError, "Fields #{diff.join(',')} not provided"
+            end
+          end
           struct_initialize(*members.map { |m| attrs.first[m.to_sym] })
         else
           struct_initialize(*attrs)

--- a/spec/immutable_struct_spec.rb
+++ b/spec/immutable_struct_spec.rb
@@ -50,6 +50,12 @@ describe ImmutableStruct do
     obj.a.should == nil
     obj.b.should == 2
   end
+
+  it 'creates a strict constructor that needs all fields' do
+    StrictImmutableItem = ImmutableItem.strict
+    lambda { StrictImmutableItem.new(:b => 2) }.should raise_error(ArgumentError)
+    lambda { ImmutableItem.new(:b => 2) }.should_not raise_error(ArgumentError)
+  end
   
   it 'does not create a hash constructor for single-field instances' do
     obj = ImmutableStruct.new(:a).new(:some => :data)


### PR DESCRIPTION
Enable creating a "strict" struct which raises error if all specified fields are not given to the Hash constructor.
